### PR TITLE
fixes for author names/orcid matching in some special cases

### DIFF
--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -111,14 +111,13 @@ while True:  # read up to where authors start
 authors = {}  # read author names and superscripts for affiliations
 for i,bit in enumerate(line.split('}')[:-1]):
     bit2 = bit.split('\\textsuperscript{')
-    if bit2[0].startswith(','):
-        nm = bit2[0][1:].lstrip()
-        if nm.startswith('and'):
-            nm = nm[3:].lstrip()
-        elif nm.startswith('&'):
-            nm = nm[1:].lstrip()
-    else:
-        nm = bit2[0]
+    nm = bit2[0].lstrip().rstrip()
+    if nm.startswith(','):
+        nm = nm[1:].lstrip().rstrip()
+    if nm.startswith('&'):
+        nm = nm[1:].lstrip()
+    if nm.startswith('and'):
+        nm = nm[3:].lstrip()
     sp = bit2[1]
     authors[i] = {'name':nm.lstrip().rstrip(),'supers':sp}
 
@@ -171,11 +170,13 @@ while True:
         if line.startswith('\hypertarget') or line.startswith('\section'):
             break
         # figure out who the author is, locate in author dict
+        orcid_claimed = False
         for k in authors.keys():
-            if authors[k]['name'] == line.split(':')[0]:
+            if ut.author_aliases(line.split(':')[0],authors[k]['name']):
                 authors[k]['orcid'] = line.split(':')[1].lstrip().rstrip()
-# TODO: author names full, orcid list has first initials only - try by A. Name if not matched initially
-# NOTE could this be a regex thing? maybe, maybe not
+                orcid_claimed = True
+        if not orcid_claimed:
+            print('orcid ',line.split(':'),' not matched to author list')
 
 # parse CRediT section, make a dict for that
 ftex_in.seek(0)

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -208,6 +208,35 @@ def non_breaking_space(to_write):
     return to_write
 
 
+def author_aliases(orcid_name,author_name):
+    """
+    check if a name listed for an orcid is the same as a name from the author list
+    if the orcid name is initials and the author name is not, reduce author name to initials
+    we are implicitly assuming that authors will not fill in orcids using initials if there
+        are co-authors with identical initials
+    """
+    match = False  # assume the names do not match to start with
+
+    # naive check if the two match
+    if author_name == orcid_name:
+        match = True
+
+    # if they don't, check if orcid_name is abbreviated at all
+    else:
+        orcid_given = orcid_name.split(' ')[0]
+        orcid_last = orcid_name.split(' ')[-1]
+        if re.match(r'[A-Z]\.',orcid_given):  # given name is abbreviated, at least
+            # get initials from author_name and compare sans .s
+            orcid_init = ''.join(c for c in orcid_name if c.isupper())
+            author_bits = author_name.split(' ')
+            author_init = ''.join(c[0] for c in author_bits)  # hopefully this works even for
+                                    # names like McDonald etc
+                                    # NOTE might fail for van den Something
+            if orcid_init == author_init:
+                match = True
+    return match
+
+
 nonasc = {'−':'\\textendash','≤':'$\leq$','≥':'$\geq$','μ':'$\mu$','°':'$^\circ$',\
             'ö':'ö','é':'é','é':'é','ć':'ć'}
 


### PR DESCRIPTION
catch orcids listed with initials when authors are full names, and also properly trimming 'and' out of author lists.