### PR TITLE
try to process tables and their captions

### DIFF
--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -344,9 +344,9 @@ while not goto_end:
                         else:
                             fullcap = test
                         if to_write.startswith('\\textbf{Figure'):
-                            figcap[tag] = fullcap
+                            figcap[tag] = fullcap.lstrip().rstrip()
                         elif to_write.startswith('\\textbf{Table'):
-                            tabcap[tag] = fullcap
+                            tabcap[tag] = fullcap.lstrip().rstrip()
                     to_write = ''
             elif to_write[0].islower():           # lines (paragraphs) that start with lowercase
                 ftex_out.write('\\noindent \n')   # are probably continuing sentences after eqns
@@ -385,14 +385,14 @@ while True:
             else:
                 ftex_out.write(t)
 
-    elif line.startswith('\\begin{table}'):
+    elif line.startswith('\\begin{table'):
         temp = [line]
         while True:
             line = ftex_in.readline()
             temp.append(line)
             if line.startswith('\label'):
                 tag = line.split('\label{')[1].split('}')[0]
-            if line.startswith('\end{table}'):  # can't be \end{tabular}
+            if line.startswith('\end{table'):  # can't be \end{tabular}
                 break
 
         for t in temp:


### PR DESCRIPTION
pandoc does a mediocre job of converting tables. We previously just took the whole messy environment out of pandoc, put it in junk, and wrote in a placeholder for each table that had to be manually replaced. Now, we strip pandoc's table formatting off of the lines that contain tabular data, and wrap them in a nicer way. Manual adjustment still needed for column widths (and if anyone used merged cells) and hlines etc.