### PR TITLE
Hypertarget section fix

### DIFF
--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -384,10 +384,11 @@ while not goto_end:
                         fullcap = tag.join(np.append(test,splits[2:]))
                     else:
                         fullcap = test
+                    fullcap = fullcap.lstrip('.').strip() # strip accidental leading . and/or spaces
                     if start_figcap or regex_figcap:
-                        figcap[tag] = fullcap.lstrip().rstrip()
+                        figcap[tag] = fullcap
                     elif start_tabcap or regex_tabcap:
-                        tabcap[tag] = fullcap.lstrip().rstrip()
+                        tabcap[tag] = fullcap
                     to_write = ''
 
             elif to_write[0].islower():           # lines (paragraphs) that start with lowercase

--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -19,7 +19,6 @@ import os, sys, re
     # Table and Figure captions start with the capitalized words 'Table' or 'Figure'
 # TODO:
     # finding ORCID and CRediT sections if not automatically ID'd
-    # scan for URLs, wrap with \url{} for line breaking
 ########################################################################
 
 ########################################################################

--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -36,7 +36,7 @@ assert os.path.isfile(tex_in),'input tex file does not exist'
 tex_out = args.ofile
 if tex_out == None:
     tex_out = tex_in[:-4] + '_corr.tex'
-    print('using %s for output file' % tex_out
+    print('using %s for output file' % tex_out)
 tex_premid = 'pandoc_cleaned.tex'
 tex_mid = 'temp.tex'
 junk_out = 'junk.tex'  # this is for table and figure info that can't be parsed automatically

--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -195,13 +195,13 @@ for i in range(struct[credit_key]['line']+1):
     line = ftex_in.readline()  # read up to CRediT section
 
 # read from start of credit section to start of subsequent section
-credits = {}
+credit = {}
 for i in range(struct[credit_key]['line']+1,struct[credit_key+1]['line']):
     line = ftex_in.readline()
     if line != '\n':
         key = line.split(':')[0]
         vals = line.split(':')[1].lstrip().rstrip()
-        credits[key] = vals
+        credit[key] = vals
 
 # go to the abstract and start reading that stuff
 ftex_in.seek(0)
@@ -273,7 +273,7 @@ if line.lower().startswith(r'\section{non-technical summary'):
 
 
 # feed some info to the header setup code
-ftex_out = tt.set_up_header(ftex_out,article_title,authors=authors,affils=affils,credits=credits,\
+ftex_out = tt.set_up_header(ftex_out,article_title,authors=authors,affils=affils,credits=credit,\
             other_langs=other_langs)
 
 # add abstract(s) after header

--- a/parse_pandoc_file.py
+++ b/parse_pandoc_file.py
@@ -42,6 +42,7 @@ tex_out = args.ofile
 if tex_out == None:
     of1 = tex_in[:-4] + '_corr.tex'
     tex_out = input('Enter path to output tex file, or use %s: ' % of1) or of1 
+tex_premid = 'pandoc_cleaned.tex'
 tex_mid = 'temp.tex'
 junk_out = 'junk.tex'  # this is for table and figure info that can't be parsed automatically
 review = False  # switch for line numbers (and single-column format) - always off for production
@@ -52,11 +53,6 @@ review = False  # switch for line numbers (and single-column format) - always of
 parser = bbl.Parser()
 biblio = parser.parse(open(bibtex,'r'))
 bibkeys = biblio.get_entries().keys()
-
-# open pandoc file and output file
-ftex_in = open(tex_in,'r')
-ftex_out = open(tex_mid,'w')
-fjunk = open(junk_out,'w')
 
 # set up counters for figures, equations, and tables
 nfig = 1; nequ = 1; ntab = 1
@@ -69,18 +65,28 @@ special_section_names = ['acknowledgements','acknowledgments',\
 skip_sections = ['references','bibliography']  # when we get to this header, skip to the end
 
 ########################################################################
-# start by scraping overall structure
+# start by cleaning some things, scraping overall structure,
 # and figuring out where the document itself starts
+
+# clean initial pandoc file for section headers
+ut.first_pandoc_clean(tex_in,tex_premid)  # outputs "pandoc_cleaned.tex"
+
+# open cleaned pandoc file ('premid') and output file
+ftex_in = open(tex_premid,'r')
+ftex_out = open(tex_mid,'w')
+fjunk = open(junk_out,'w')
+
+# get structural cues/line numbers for seeking sections later
 _,struct = ut.document_structure(ftex_in)
 
-# determine which sections are ORCIDs and CRediT
+# determine which sections are ORCIDs and CRediT, make sure those are there
 orcid_key = -1; credit_key = -1; abs1_key = -1
 for k in struct.keys():
     if struct[k]['sname'].lower().__contains__('orcid'):
         orcid_key = k
     if struct[k]['sname'].lower().__contains__('author contributions'):
         credit_key = k
-    if struct[k]['sname'].lower() == 'abstract':  # specifically, the English-language one
+    if struct[k]['sname'].lower() == 'abstract' and abs1_key < 0:  # specifically, the English-language one; should be first one found
         abs1_key = k
 
 assert orcid_key >= 0, 'Author ORCIDs section not found'
@@ -96,12 +102,15 @@ for i in range(struct['b']['line']+1):
 # if title is in the document structure, we're done!
 if 'ti' in struct.keys():
     article_title = struct['ti']['sname']
-else:  # hopefully the title is the first line after begin{document}
+else:  # hopefully the title is the first line after begin{document} if not in \title{} format
     while True:
         line = ftex_in.readline()
         if line != '\n':
             break  # this should be the title, fingers crossed
     article_title = line.rstrip() # get the title text
+# if article title is bolded or emph'd, get rid of that
+if re.match(r"\\textbf{",article_title) or re.match(r"\\emph{",article_title):
+    article_title = re.findall(r"\\textbf{(.*?)}",article_title)[0]
 
 # read in author info (names, affiliations, email for corresponding if applicable)
 while True:  # read up to where authors start
@@ -140,7 +149,7 @@ while True:
                 print('unknown afflitiation superscript; moving to junk')
                 fjunk.write(line)
                 fjunk.write('\n')
-    elif line.startswith('*'):  # corresponding author email address
+    elif line.startswith('*'):  # corresponding author email address TODO emph tag, regex
         email = line.split(':')[-1].lstrip()
         for k in authors.keys():
             if '*' in authors[k]['supers']:
@@ -153,22 +162,22 @@ for a in authors.keys():
     if '*' in authors[a]['supers']:  # need to remove extra * because \thanks takes care of that
         star_ind = authors[a]['supers'].find('*')
         if star_ind == len(authors[a]['supers'])-1:
-            authors[a]['supers'] = authors[a]['supers'][:star_ind-1]
+            authors[a]['supers'] = authors[a]['supers'][:-1]
         else:
             pre = authors[a]['supers'][:star_ind]
             post = authors[a]['supers'][star_ind+2:]
             authors[a]['supers'] = pre+post
+    authors[a]['supers'] = authors[a]['supers'].rstrip(',')  # no trailing commas just in case
 
 # parse orcids, add to author dict
 ftex_in.seek(0)
 for i in range(struct[orcid_key]['line']+1):
     line = ftex_in.readline()  # read up to ORCIDs section
 
-while True:
+# read from start of orcid section to start of subsequent section
+for i in range(struct[orcid_key]['line']+1,struct[orcid_key+1]['line']):
     line = ftex_in.readline()
     if line != '\n':  # there is something to parse
-        if line.startswith(r'\hypertarget') or line.startswith(r'\section'):
-            break
         # figure out who the author is, locate in author dict
         orcid_claimed = False
         for k in authors.keys():
@@ -183,12 +192,11 @@ ftex_in.seek(0)
 for i in range(struct[credit_key]['line']+1):
     line = ftex_in.readline()  # read up to CRediT section
 
+# read from start of credit section to start of subsequent section
 credits = {}
-while True:
+for i in range(struct[credit_key]['line']+1,struct[credit_key+1]['line']):
     line = ftex_in.readline()
     if line != '\n':
-        if line.startswith(r'\hypertarget') or line.startswith(r'\section'):
-            break
         key = line.split(':')[0]
         vals = line.split(':')[1].lstrip().rstrip()
         credits[key] = vals
@@ -203,7 +211,7 @@ summaries = {}; scount = 0
 abst = ""
 while True:
     line = ftex_in.readline()
-    if not line.startswith(r'\hypertarget'):
+    if not line.startswith(r'\section'):
         abst = abst + line.rstrip()  # this will probably be just one line(/one paragraph)
     else:                            # but there can be multi-paragraph abstracts
         break
@@ -212,32 +220,55 @@ scount += 1
 
 other_langs = []
 # deal with the second-language abstract  if there is one
-if line.startswith(r'\hypertarget{second-language-abstract'):
-    ftex_in, line, abs2_dict = ut.get_abstract(ftex_in) # this function reads up to the
+if line.lower().startswith(r'\section{second language abs'):
+    abs2_dict = {}
+    abs2 = ''
+    hdr = line.split('{')[1].split('}')[0].split(':')[-1].lstrip()  # input line is section header
+    abs2_dict['name'] = hdr.split('(')[0].rstrip()
+    abs2_dict['language'] = hdr.split('(')[-1].split(')')[0].lower()
+    while True:
+        line = ftex_in.readline()
+        if not line.startswith(r'\section'):  # until we hit the next section
+            abs2 = abs2 + line.rstrip()
+        else:
+            break 
+        #abs2 = check_non_ascii(abs2)  # try to convert any non-ascii characters
+    abs2_dict['text'] = abs2
     other_langs.append(abs2_dict['language'])                 # next \hypertarget
     summaries[scount] = abs2_dict
     scount += 1
 
 # deal with the third-language abstract  if there is one
-if line.startswith(r'\hypertarget{third-language-abstract'):
-    ftex_in, line, abs3_dict = ut.get_abstract(ftex_in)
-    other_langs.append(abs3_dict['language'])
+if line.lower().startswith(r'\section{third language abs'):
+    abs3_dict = {}
+    abs3 = ''
+    hdr = line.split('{')[1].split('}')[0].split(':')[-1].lstrip()  # input line is section header
+    abs3_dict['name'] = hdr.split('(')[0].rstrip()
+    abs3_dict['language'] = hdr.split('(')[-1].split(')')[0].lower()
+    while True:
+        line = ftex_in.readline()
+        if not line.startswith(r'\section'):  # until we hit the next section
+            abs3 = abs3 + line.rstrip()
+        else:
+            break 
+    abs3_dict['text'] = abs3
+    other_langs.append(abs3_dict['language'])                 # next \hypertarget
     summaries[scount] = abs3_dict
     scount += 1
 
-print('here')
 # parse (English-language) non-technical summary if present
-if line.startswith(r'\hypertarget{non-technical-summary'):
+if line.lower().startswith(r'\section{non-technical summary'):
     line = ftex_in.readline()  # get past \section
     nontech = ""
     while True:
         line = ftex_in.readline()
-        if not line.startswith(r'\hypertarget'):
+        if not line.startswith(r'\section'):
             nontech = nontech + line.rstrip()
         else:
             break
     summaries[scount] = {'text':nontech,'name':'Non-technical summary','language':'English'}
     scount += 1
+
 
 # feed some info to the header setup code
 ftex_out = tt.set_up_header(ftex_out,article_title,authors=authors,affils=affils,credits=credits,\
@@ -245,6 +276,7 @@ ftex_out = tt.set_up_header(ftex_out,article_title,authors=authors,affils=affils
 
 # add abstract(s) after header
 ftex_out = tt.add_abstracts(ftex_out,summaries)
+
 
 ########################################################################
 # go through the rest of the sections! and deal with citations, figures, and equations

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -415,26 +415,36 @@ def author_aliases(orcid_name,author_name):
     we are implicitly assuming that authors will not fill in orcids using initials if there
         are co-authors with identical initials
     """
-    match = False  # assume the names do not match to start with
+    ismatch = False  # assume the names do not match to start with
+
+    # pre-emptively replace all hyphens with spaces (I don't think this will be a bad thing?)
+    author_name = re.sub(r'-',' ',author_name)
+    orcid_name = re.sub(r'-',' ',orcid_name)
 
     # naive check if the two match
     if author_name == orcid_name:
-        match = True
+        ismatch = True
 
     # if they don't, check if orcid_name is abbreviated at all
     else:
         orcid_given = orcid_name.split(' ')[0]
-        orcid_last = orcid_name.split(' ')[-1]
+        orcid_last = ' '.join(orcid_name.split(' ')[1:])
         if re.match(r'[A-Z]\.',orcid_given):  # given name is abbreviated, at least
+            # check if abbreviated first name plus orcid last name matches
+            auth_given = author_name.split(' ')[0]
+            auth_last = ' '.join(author_name.split(' ')[1:])
+            auth_first_abbrev = auth_given[0] + '. ' + auth_last
+            if auth_first_abbrev == orcid_name:
+                ismatch = True  # this case should catch some van den Ende-like names
+
             # get initials from author_name and compare sans .s
             orcid_init = ''.join(c for c in orcid_name if c.isupper())
             author_bits = author_name.split(' ')
             author_init = ''.join(c[0] for c in author_bits)  # hopefully this works even for
                                     # names like McDonald etc
-                                    # NOTE might fail for van den Something
             if orcid_init == author_init:
-                match = True
-    return match
+                ismatch = True
+    return ismatch
 
 
 nonasc = {'−':r'\textendash','≤':r'$\leq$','≥':r'$\geq$','μ':r'$\mu$','°':r'$^\circ$',\

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -468,29 +468,6 @@ def check_non_ascii(line):
 
     return oline
 
-def get_abstract(ftex_in):
-    """
-    after finding second- or third-language abstract header, read and parse that abstract
-    return abstract text and dict with abstract info (language, heading)
-    """
-    abs2_dict = {}
-    abs2 = ''
-    while True:
-        line = ftex_in.readline()
-        if line.startswith(r'\section'):
-            hdr = line.split('{')[1].split('}')[0].split(':')[-1].lstrip()
-            abs2_dict['name'] = hdr.split('(')[0].rstrip()
-            abs2_dict['language'] = hdr.split('(')[-1].split(')')[0].lower()
-        else:
-            if not line.startswith(r'\hypertarget'):  # until we hit the next section
-                abs2 = abs2 + line.rstrip()
-            else:
-                break 
-        #abs2 = check_non_ascii(abs2)  # try to convert any non-ascii characters
-        abs2_dict['text'] = abs2
-
-    return ftex_in, line, abs2_dict
-
 def print_reminders(ofile_tex):
     print('An output tex file has been written at: %s' % ofile_tex)
     print('Unparsable table/figure info is in junk.tex')

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -89,7 +89,7 @@ def first_pandoc_clean(ifile,ofile):
             elif re.findall(r'\\(?:(sub){0,3})section',line):  # section is in this line
                 q = list(re.finditer(r'\\(?:(sub){0,3})section',line))
                 line = line[q[0].start():]  # slice to where the section tag starts
-        if re.match(r'texorpdfstring',line) and not skipline:  # has a texorpdfstring thingy, not skipped
+        if re.findall(r'texorpdfstring',line) and not skipline:  # has a texorpdfstring thingy, not skipped
             line = re.sub(r"\\texorpdfstring{(.*?)}",r"",line)  # get rid of that tag
 
         # if a (sub)section line, check for ending labels and strip them off
@@ -97,6 +97,11 @@ def first_pandoc_clean(ifile,ofile):
             q = list(re.finditer(r'\\label{(.*?)}',line))
             line = line[:q[0].start()]
 
+        # check for excess brackets
+        if re.match(r"\\(?:(sub){0,3})section",line):
+            line = re.sub(r"{{",r"{",line)
+            line = re.sub(r"}}",r"}",line)
+                
         if not skipline:
             ftex_out.write(line)
             ftex_out.write('\n')
@@ -121,10 +126,8 @@ def document_structure(ftex_in):
     j = 0  # section heading counter
     while i < nln:
         line = ftex_in.readline()
-        if line.startswith(r'\hypertarget'):  # next line will be section heading
-            i += 1
-            line = ftex_in.readline()  # this will be the heading
-            if line.split('{')[1][0].isdigit():
+        if re.match(r'\\(?:(sub){0,3})section',line):  # section header
+            if line.split('{')[1].strip()[0].isdigit():  # try to remove numbering
                 sname = ' '.join(line.split('{')[1].split('}')[0].split(' ')[1:])
             else:
                 sname = line.split('{')[1].split('}')[0]


### PR DESCRIPTION
Update prompted by apparent changes to pandoc behavior - seems to have gotten better at recognizing section headings, so instead of relying on "hypertarget" tags associated with heading styles, switch to stripping out all of those and looking for tex (sub)section tags directly. Several other things are also updated (orcid/author name matching, affiliation parsing, some raw strings missed the first time around). Did not finish working on the enumerate bug bc I can't find the docx file to replicate it right now.