### PR TITLE
Automate adding DOIs to bib files with crossref API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ These scripts are for converting docx/odt manuscript submissions into latex, spe
 ## dependencies:
 - python 3.n (preferably 3.8+)
 - numpy
+- [habanero](https://habanero.readthedocs.io/)
+- [dateutil](https://dateutil.readthedocs.io/en/stable/)
 - [biblib](https://github.com/WeAreSeismica/biblib) (NOT from conda or pip)
 - [pandoc](pandoc.org/)
 - [anystyle](https://github.com/inukshuk/anystyle) or a web browser to access [anystyle.io](anystyle.io)
 
 A [conda](conda.io) environment is a nice way to set up the python dependencies. You could, for example, use these commands:
 
-- `conda create -n seismica numpy`
+- `conda create -n seismica numpy habanero python-dateutil`
 - `cd /path/to/put/biblib/files`
 - `git clone git@github.com:WeAreSeismica/biblib.git`
 - `conda activate seismica`

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Alternatively, you can use [docker](docker.com), with instructions provided belo
     - running the anystyle gem locally: copy the text of the references into a plain text file (e.g. `refs.txt`) with one reference per line, and then run `anystyle -f bib parse refs.txt .` to generate the file `refs.bib` (filename will be the same as the input, with suffix replaced by .bib)
     - copy-pasting bibliography from docx/odt into anystyle.io, and copy-pasting the output into a new .bib file
 
-1. fix anystyle bibtex file year fields and keys, make a new .bib file
+1. fix anystyle bibtex file year fields and keys, make a new .bib file. This script will query crossref to try and add missing DOIs to references. Interactive prompts are used to check the results of crossref queries so as not to introduce errors.
     - `python3 -m fix_bibtex --ifile refs.bib --ofile refs_better.bib`
 
 1. parse the pandoc output tex file to a better tex format
     - `python3 -m parse_pandoc_file --bibfile refs_better.bib --ifile file_pandoc.tex --ofile file_better.tex`
-    - unparsed tables and other confusing text will go in `junk.tex`
+    - bits that can't be parsed automatically will go in `junk.tex`
     - `temp.tex` is used for intermediate stages of parsing
 
 1. make pdf by either:
@@ -78,14 +78,13 @@ Alternatively, you can use [docker](docker.com), with instructions provided belo
     - manually set options (breakmath, languages, report, etc) as necessary
     - manually link figure files (that the author uploaded separately) at the right sizes (1- or 2-column)
     - manually adjust for any citations that we couldn't parse (most should be marked in red, but some may have been missed altogether)
+    - manually adjust table formatting
     - add extra hyphenation rules for words latex doesn't know if columns are overfull
-    - manually wrap any urls in the text that weren't caught with \url{}
-    - look at junk file and manually reformat/place tables in text where they belong
+    - look at junk file and edit/replace any pieces that were not parsed
 
 ## TODO: 
 - multi-line equations in brackets/parens! These are a problem, they break the paren parsing.
 - print warning for references that start with special characters
-- figure out longtable/table parsing to seistable so we don't need to move things to junk
 - check for excess . at the beginnings of captions when bold formatting isn't perfect, and strip trailing newlines from captions (for tex2jats)
 - can we catch captions even when "Figure 1"/"Table 1" is *not* bold? They should be bold but are not always
 - check YYYYa/YYYYb citations

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,8 @@ RUN python3 -m pip install pip --upgrade --no-cache \
 	pip \
 	setuptools \
 	numpy \
+        habanero \
+        python-dateutil \
 	git+https://github.com/WeAreSeismica/biblib
 
 WORKDIR /data

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -12,7 +12,6 @@ import os, sys, re, random, string
     # try to find dois where they are missing
     # get nice citations from crossref when we do have dois
     # neaten up bibtex entries, with clean keys for docx/odt parsing
-# TODO why are keys being lower-cased??
 # TODO un-tex/html-escape special characters from crossref search? like &lt; and {\'{e}} or whatever
 ####
 
@@ -89,7 +88,7 @@ for key in bib_OD:  # loop entry keys
             # parse to an Entry and check to make sure all the pieces are there
             parser = bbl.Parser()
             parsed = parser.parse(bibtext)
-            entry_new = parsed.get_entries()[key0.lower()]
+            entry_new = parsed.get_entries()[key0]
             rereparse = False
             if 'author' not in entry_new.keys() and 'author' in entry.keys():  # avoid losing info
                 entry_new['author'] = entry['author']
@@ -100,7 +99,7 @@ for key in bib_OD:  # loop entry keys
             if rereparse:  # info has been added, re-parse to reset field_pos
                 parser = bbl.Parser()
                 parsed = parser.parse(entry_new.to_bib())
-                entry_new = parsed.get_entries()[key0.lower()]
+                entry_new = parsed.get_entries()[key0]
         except HTTPError:  # shouldn't hit this bc crossref dois should work, but who knows
             entry_new = entry  # keep whatever the initial entry was
                         

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -24,6 +24,7 @@ import os, sys, re
     # like &lt; and {\'{e}} or whatever (this tends to come up with authors and titles)
     # for now this is taken care of by option to keep old entry title and/or authors
 # TODO do we really need to keep page number info? tends to be poorly curated/mixed bag
+# TODO query limit 5 or so, options for scrolling back and forth before choosing a ref (or not)
 ####
 
 parser = ArgumentParser()
@@ -63,7 +64,6 @@ for key in bib_OD:  # loop entry keys
     entry = bib_OD[key]
     doi = None   # to start, assume no doi
     if 'doi' in entry.keys(): # get provided doi if present, check to make sure it will work
-        # TODO: doi:[doi] format still comes up sometimes, catch that
         if entry['doi'][-1] == '.':             # check if doi ends with . and if it does, get rid of the .
             entry['doi'] = entry['doi'][:-1]    # (this is sometimes an anystyle problem)
         doi = entry['doi']
@@ -83,9 +83,6 @@ for key in bib_OD:  # loop entry keys
             doi = None  # url is not actually a good DOI link
 
     if not doi:  # try querying crossref to get a doi
-        # TODO do we want a while loop to query for more than 2 entries if someone wants to go furter down the
-        # list of potential matches? might be more than we need but not too hard to implement
-        # should probably set a max returns regardless (ie limit=5) to be nice to crossref
         try:
             q = cr.works(query_bibliographic=entry['title'],query_author=entry['author'],\
                         limit=2,select='DOI,title,author,score,type,published',sort='score')

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -12,7 +12,9 @@ import os, sys, re, random, string
     # try to find dois where they are missing
     # get nice citations from crossref when we do have dois
     # neaten up bibtex entries, with clean keys for docx/odt parsing
+# TODO query two deep and check to make sure first isn't a preprint of the second
 # TODO un-tex/html-escape special characters from crossref search? like &lt; and {\'{e}} or whatever
+# this tends to come up with authors and titles
 ####
 
 parser = ArgumentParser()
@@ -34,7 +36,7 @@ if os.path.isfile(out_bib):
     if iq == 'n':
         sys.exit()
 
-cr = Crossref(mailto="tech@seismica.org")  # connection for querying
+cr = Crossref(mailto="tech@seismica.org",ua_string='Seismica SCE, seismica.org')  # connection for querying
 
 parser = bbl.Parser()  # parser for bibtex
 parsed = parser.parse(open(in_bib,'r'))  # parse the input file with biblib
@@ -62,7 +64,7 @@ for key in bib_OD:  # loop entry keys
             doi = None  # authors were wrong or anystyle messed up; try a search
 
     if not doi:  # try querying crossref for this
-        q = cr.works(query=entry['title'],query_author=entry['author'],limit=1,select='DOI,title,author')
+        q = cr.works(query_bibliographic=entry['title'],query_author=entry['author'],limit=1,select='DOI,title,author,score',sort='score')
         print('\nqueried for:\ntitle: %s\nby: %s\n' % (entry['title'],entry['author']))
         # TODO print first author nicer; need to catch 'name' case as well as 'given' 'family'
         print('received:\ntitle: %s\n1st auth: %s\ndoi: %s\n' % (q['message']['items'][0]['title'][0],\

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -1,5 +1,6 @@
 import numpy as np
 import biblib.bib as bbl
+import dateutil.parser as dp
 from habanero import Crossref
 from argparse import ArgumentParser
 from collections import Counter
@@ -39,51 +40,42 @@ fout = open('temp.bib','w')  # for doi'd entries, will overwrite if file exists
 # loop entry keys
 for key in bib_OD:
     entry = bib_OD[key]
-
-    # TODO check if there's a doi, and use it to query crossref for good ref information if so
-    if 'doi' not in entry.keys():  # query crossref and try to get a doi
+    # TODO if url us a key and doi is not, check if url is actually a doi
+    if 'doi' not in entry.keys():  # if no doi, query crossref to try and get one
         q = cr.works(query=entry['title'],query_author=entry['author'],limit=2,select='DOI,title,author')
-        print('queried for:\n%s\nby:%s\n' % (entry['title'],entry['author']))
-        print('received:\n%s\nfirst auth %s\n%s\n' % (q['message']['items'][0]['title'][0],\
+        print('\nqueried for:\ntitle: %s\nby: %s\n' % (entry['title'],entry['author']))
+        print('received:\ntitle: %s\n1st auth: %s\ndoi: %s\n' % (q['message']['items'][0]['title'][0],\
                 q['message']['items'][0]['author'][0],\
                 q['message']['items'][0]['DOI']))
-        iok = input('accept entry [Y]/n:\n') or 'Y'
+        iok = input('accept entry [Y]/n: ') or 'Y'
         if iok.lower() == 'y':
             doi = q['message']['items'][0]['DOI']
         else:
             doi = None
 
-    else:
+    else:  # if there is a doi, grab it
         if entry['doi'][-1] == '.':  # check if doi ends with . and if it does, get rid of the .
             entry['doi'] = entry['doi'][:-1]
         doi = entry['doi']
-    if doi:  # ie not None
-        # since there is a DOI, use it to query for a clean citation in case authors messed up
-        #if '(' in doi:
-        #    pre = doi[0:doi.find('(')]
-        #    suff = doi[doi.find(')')+1::]
-        #    mid = doi[doi.find('(')+1:doi.find(')')]
-        #    ourl = "https://dx.doi.org/"+pre+"\("+mid+"\)"+suff
-        #elif '. ' in doi:
+    if doi:  # if doi not none, use to query for a clean citation
         if '. ' in doi:
             ourl = "https://dx.doi.org/"+doi[0:doi.find('. ')]
         else:
             ourl = "https://dx.doi.org/"+doi
-        # now try to query crossref for it
         req = Request(ourl, headers=dict(Accept='text/bibliography; style=bibtex'))
         bibtext = urlopen(req).read().decode('utf-8')
         bibtext = bibtext.lstrip()  # clean leading space
-        # try to make a unique key; we'll fix these later
-        key_yr = re.findall('@[a-z]*{([0-9]{4})',bibtext)[0]
-        extra_letters = ''.join(random.choices(string.ascii_letters,k=5))
-        pieces = bibtext.split(key_yr)
-        start = pieces[0] + extra_letters + key_yr + pieces[1]
+        # try to make a unique bibtex key bc biblib needs unique keys to read; we'll fix these later
+        key_yr = re.findall('@[a-z]*{([0-9]{4})',bibtext)[0]  # extract auto key (should be year)
+        extra_letters = ''.join(random.choices(string.ascii_letters,k=5))  # random tag
+        pieces = bibtext.split(key_yr)  # split around key (will also split at year entry)
+        start = pieces[0] + extra_letters + key_yr + pieces[1]  # add in new bibtex key
         new_pieces = [start,]
         for p in pieces[2:]:
-            new_pieces.append(p)
-        bibtext_out = key_yr.join(new_pieces)
-        fout.write(bibtext_out)
-    else:
+            new_pieces.append(p)  # put list back together
+        bibtext_out = key_yr.join(new_pieces)  # rejoin around year entry
+        fout.write(bibtext_out)  # write
+    else:  # no doi, nothing to search with
         fout.write(entry.to_bib())  # just write what we had to start with
         fout.write('\n')
 
@@ -99,21 +91,6 @@ parsed = parser.parse(open('temp.bib','r'))  # parse the input file with biblib
 # get entries
 bib_OD = parsed.get_entries()  # returns collections.OrderedDict
 
-# check if all the titles end with an apostrophe; if so, probably an error and they need to 
-# be removed (probably quoted titles and anystyle only removed the leading quote)
-# this may not be an issue anymore since we should get clean titles from crossref mostly?
-# TODO deal with this for things that are not queried
-last_char = np.array([bib_OD[key]['title'][-1] for key in bib_OD])
-strp_last = False
-lc = Counter(last_char)
-if max(lc.values()) >= len(last_char)/2:  # this is a red flag
-    print('title trailing characters:')
-    for i,k in enumerate(lc.keys()):
-        print('[%i] %i instances of %s' % (i,lc[k],k))
-    irem = int(input('enter index to remove: ') or -1)
-    if irem >= 0: 
-        strp_last = True  # and we'll remove the one with that index in the keys list
-        char_out = list(lc.keys())[irem]
 
 # open outfile for writing
 fout = open(out_bib,'w')  # will overwrite if file exists
@@ -129,42 +106,44 @@ for key in bib_OD:
     if 'date' in entry.keys():
         if len(entry['date']) == 4: # assume this means it's a year, which is probably true
             entry['year'] = entry['date']
-        else: # possibly 'month year'? or some other format, check on that
-            entry['year'] = entry['date'].split(' ')[-1]
-            if len(entry['year']) != 4:
-                print('date is %s, year set to %s' % (entry['date'],entry['year']))
-                iy = input('enter corrected year if needed: ') or None
-                if iy != None:
-                    entry['year'] = iy
+        else: # some other format, try to parse
+            try_year = dp.parse(entry['date']).year
+            print('date is %s, year set to %s' % (entry['date'],try_year))
+            iy = input('enter corrected year if needed: ') or None
+            if iy != None:
+                entry['year'] = iy
     if 'url' in entry.keys():
         if re.search(r"doi\.org",entry['url']):  # check if url is just a doi link
-            _ = entry.pop('url')
-# TODO if there is a url but no doi and the url is a doi, repurpose
+            _ = entry.pop('url')  # if it is, we should have used it earlier and can clean now
 
-#    if 'pages' in entry.keys():
+    # TODO decide if pages should ever be kept
+    # tends to be a messy field; sometimes an id#, sometimes page range, sometimes number of pages
+#    if 'pages' in entry.keys():  
 #        _ = entry.pop('pages')
 
     if 'pages' in entry.keys():
-        entry['pages'] = entry['pages'].rstrip(',')  # get rid of any trailing commas
+        entry['pages'] = entry['pages'].rstrip(',')  # at least get rid of any trailing commas
 
     if 'note' in entry.keys():
         entry['note'] = re.sub(r'Available at','',entry['note'])
         if len(entry['note']) <= 3:  # if we've only got 3 characters left or less, probably nothing
             _ = entry.pop('note')  # should take care of case with : at the end
 
-    if strp_last:
-        if entry['title'].endswith(char_out):
-            entry['title'] = entry['title'][:-1]  # remove trailing apostrophe (probably)
+    if entry['title'].endswith("'"):
+        entry['title'] = entry['title'][:-1]  # remove trailing apostrophe if present
+
+    # clean up first author name: no {}, no spaces
+    auth0 = re.sub(r'[ ]',r'',entry.authors()[0].last.lstrip('{').rstrip('}'))
 
     # for each, reformat key to be what we'd look for in inline citations
     # first, count authors: if >2, key is firstauthorEAYYYY, if 2 or less is author(author)YYYY
-    # TODO deal with {} in author lists if it comes up
     if len(entry.authors()) > 2:
-        newkey = entry.authors()[0].last + 'EA' + entry['year']
+        newkey = auth0 + 'EA' + entry['year']
     elif len(entry.authors()) == 2:
-        newkey = entry.authors()[0].last + entry.authors()[1].last + entry['year']
+        auth1 = re.sub(r'[ ]',r'',entry.authors()[1].last.lstrip('{').rstrip('}'))
+        newkey = auth0 + auth1 + entry['year']
     elif len(entry.authors()) == 1:
-        newkey = entry.authors()[0].last + entry['year']
+        newkey = auth0 + entry['year']
     newkey = newkey.replace(" ","")  # get rid of spaces if there are any (like van Keken or something)
     newkey = newkey.replace("-","")  # get rid of hyphens, which tex2jats doesn't like
     nextletter = 'a'

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -120,13 +120,12 @@ for key in bib_OD:  # loop entry keys
         req = Request(ourl, headers=dict(Accept='application/x-bibtex'))
         try:
             bibtext = urlopen(req).read().decode('utf-8')
-            pieces = bibtext.split('\n')  # get bibtex key that comes with the downloaded entry
-            key0 = pieces[0].split('{')[1].rstrip(',')
 
             # parse bibtex to an Entry and check to make sure all the main pieces are there
             # we need this bc some metadata deposited with DOIs is imperfect in weird ways
             parser = bbl.Parser()  # need a new parser every time which is annoying
             parsed = parser.parse(bibtext)
+            key0 = list(parsed.get_entries().keys())[0]
             entry_new = parsed.get_entries()[key0]  # keyed based on doi.org convention
 
             # see if we need to fix/un-replace authors or titles

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -4,7 +4,7 @@ import dateutil.parser as dp
 from habanero import Crossref
 from argparse import ArgumentParser
 from collections import Counter
-from urllib.request import Request, urlopen
+from urllib.request import Request, urlopen, HTTPError
 import os, sys, re, random, string
 
 ####
@@ -12,6 +12,7 @@ import os, sys, re, random, string
     # try to find dois where they are missing
     # get nice citations from crossref when we do have dois
     # neaten up bibtex entries, with clean keys for docx/odt parsing
+# TODO deal with the case where the supposedly "cleaner" doi-search entry is missing author info
 # TODO option to keep initial keys so we can run this on authors' tex files as well as anystyle
 ####
 
@@ -33,7 +34,7 @@ if os.path.isfile(out_bib):
     if iq == 'n':
         sys.exit()
 
-cr = Crossref(mailto="hmark@whoi.edu")  # connection for querying
+cr = Crossref(mailto="tech@seismica.org")  # connection for querying
 
 parser = bbl.Parser()  # parser for bibtex
 parsed = parser.parse(open(in_bib,'r'))  # parse the input file with biblib
@@ -47,7 +48,9 @@ fout = open('temp.bib','w')  # for doi'd entries, will overwrite if file exists
 for key in bib_OD:  # loop entry keys
     entry = bib_OD[key]
     # TODO if url us a key and doi is not, check if url is actually a doi
+    searched_doi = False
     if 'doi' not in entry.keys():  # if no doi, query crossref to try and get one
+        searched_doi = True  # flag to say that we are trying a crossref query for this one
         q = cr.works(query=entry['title'],query_author=entry['author'],limit=2,select='DOI,title,author')
         print('\nqueried for:\ntitle: %s\nby: %s\n' % (entry['title'],entry['author']))
         # TODO print first author nicer; need to catch 'name' case as well as 'given' 'family'
@@ -60,27 +63,57 @@ for key in bib_OD:  # loop entry keys
         else:
             doi = None
 
-    else:  # if there is a doi, grab it
+    else:  # if there is a doi in there already, grab it
         if entry['doi'][-1] == '.':  # check if doi ends with . and if it does, get rid of the .
             entry['doi'] = entry['doi'][:-1]
         doi = entry['doi']
+
     if doi:  # if doi not none, use to query for a clean citation
         if '. ' in doi:
             ourl = "https://dx.doi.org/"+doi[0:doi.find('. ')]
         else:
             ourl = "https://dx.doi.org/"+doi
         req = Request(ourl, headers=dict(Accept='application/x-bibtex'))
-        bibtext = urlopen(req).read().decode('utf-8')
-        bibtext = bibtext.lstrip()  # clean leading space
-        # make sure bibtex key is unique for biblib; we'll fix these later
-        pieces = bibtext.split('\n')
-        key0 = pieces[0].split('{')
-        key0[-1] = key0[-1].rstrip(',') + ''.join(random.choices(string.ascii_letters,k=5)) + ','
-        pieces[0] = '{'.join(key0)
-        bibtext_out = '\n'.join(pieces)
-        fout.write(bibtext_out)  # write
-        fout.write('\n')
-    else:  # no doi, nothing to search with
+        try:
+            bibtext = urlopen(req).read().decode('utf-8')
+            bibtext = bibtext.lstrip()  # clean leading space
+            # make sure bibtex key is unique for biblib; we'll fix these later
+            pieces = bibtext.split('\n')
+            key0 = pieces[0].split('{')
+            key0[-1] = key0[-1].rstrip(',') + ''.join(random.choices(string.ascii_letters,k=5)) + ','
+            pieces[0] = '{'.join(key0)
+            bibtext_out = '\n'.join(pieces)
+            fout.write(bibtext_out)  # write
+            fout.write('\n')
+        except HTTPError:  # url does not return (sometimes anystle messes up dois, or authors do)
+            if not searched_doi:  # we haven't already tried crossref, so try it here
+                q = cr.works(query=entry['title'],query_author=entry['author'],limit=2,select='DOI,title,author')
+                print('\nqueried for:\ntitle: %s\nby: %s\n' % (entry['title'],entry['author']))
+                # TODO print first author nicer; need to catch 'name' case as well as 'given' 'family'
+                print('received:\ntitle: %s\n1st auth: %s\ndoi: %s\n' % (q['message']['items'][0]['title'][0],\
+                        q['message']['items'][0]['author'][0],\
+                        q['message']['items'][0]['DOI']))
+                iok = input('accept entry [Y]/n: ') or 'Y'
+                if iok.lower() == 'y':
+                    doi = q['message']['items'][0]['DOI']
+                    ourl = "https://dx.doi.org/"+doi
+                    req = Request(ourl, headers=dict(Accept='application/x-bibtex'))
+                    try:  # see if this one will resolve
+                        bibtext = urlopen(req).read().decode('utf-8')
+                        bibtext = bibtext.lstrip()  # clean leading space
+                        # make sure bibtex key is unique for biblib; we'll fix these later
+                        pieces = bibtext.split('\n')
+                        key0 = pieces[0].split('{')
+                        key0[-1] = key0[-1].rstrip(',') + ''.join(random.choices(string.ascii_letters,k=5)) + ','
+                        pieces[0] = '{'.join(key0)
+                        bibtext_out = '\n'.join(pieces)
+                        fout.write(bibtext_out)  # write
+                        fout.write('\n')
+                    except HTTPError:  # url *still* does not return
+                        fout.write(entry.to_bib())  # just write what we had to start with
+                        fout.write('\n')
+                        
+    else:  # no doi, nothing to search with; just write the initial entry
         fout.write(entry.to_bib())  # just write what we had to start with
         fout.write('\n')
 

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -1,8 +1,10 @@
 import numpy as np
 import biblib.bib as bbl
+from habanero import Crossref
 from argparse import ArgumentParser
 from collections import Counter
-import os, sys, re
+from urllib.request import Request, urlopen
+import os, sys, re, random, string
 
 parser = ArgumentParser()
 parser.add_argument('--ifile','-i',type=str,help='path to input file')
@@ -22,14 +24,85 @@ if os.path.isfile(out_bib):
     if iq == 'n':
         sys.exit()
 
+cr = Crossref(mailto="hmark@whoi.edu")  # connection for querying
+
 parser = bbl.Parser()  # parser for bibtex
 parsed = parser.parse(open(in_bib,'r'))  # parse the input file with biblib
 
 # get entries
 bib_OD = parsed.get_entries()  # returns collections.OrderedDict
 
+
+# open outfile for writing
+fout = open('temp.bib','w')  # for doi'd entries, will overwrite if file exists
+
+# loop entry keys
+for key in bib_OD:
+    entry = bib_OD[key]
+
+    # TODO check if there's a doi, and use it to query crossref for good ref information if so
+    if 'doi' not in entry.keys():  # query crossref and try to get a doi
+        q = cr.works(query=entry['title'],query_author=entry['author'],limit=2,select='DOI,title,author')
+        print('queried for:\n%s\nby:%s\n' % (entry['title'],entry['author']))
+        print('received:\n%s\nfirst auth %s\n%s\n' % (q['message']['items'][0]['title'][0],\
+                q['message']['items'][0]['author'][0],\
+                q['message']['items'][0]['DOI']))
+        iok = input('accept entry [Y]/n:\n') or 'Y'
+        if iok.lower() == 'y':
+            doi = q['message']['items'][0]['DOI']
+        else:
+            doi = None
+
+    else:
+        if entry['doi'][-1] == '.':  # check if doi ends with . and if it does, get rid of the .
+            entry['doi'] = entry['doi'][:-1]
+        doi = entry['doi']
+    if doi:  # ie not None
+        # since there is a DOI, use it to query for a clean citation in case authors messed up
+        #if '(' in doi:
+        #    pre = doi[0:doi.find('(')]
+        #    suff = doi[doi.find(')')+1::]
+        #    mid = doi[doi.find('(')+1:doi.find(')')]
+        #    ourl = "https://dx.doi.org/"+pre+"\("+mid+"\)"+suff
+        #elif '. ' in doi:
+        if '. ' in doi:
+            ourl = "https://dx.doi.org/"+doi[0:doi.find('. ')]
+        else:
+            ourl = "https://dx.doi.org/"+doi
+        # now try to query crossref for it
+        req = Request(ourl, headers=dict(Accept='text/bibliography; style=bibtex'))
+        bibtext = urlopen(req).read().decode('utf-8')
+        bibtext = bibtext.lstrip()  # clean leading space
+        # try to make a unique key; we'll fix these later
+        key_yr = re.findall('@[a-z]*{([0-9]{4})',bibtext)[0]
+        extra_letters = ''.join(random.choices(string.ascii_letters,k=5))
+        pieces = bibtext.split(key_yr)
+        start = pieces[0] + extra_letters + key_yr + pieces[1]
+        new_pieces = [start,]
+        for p in pieces[2:]:
+            new_pieces.append(p)
+        bibtext_out = key_yr.join(new_pieces)
+        fout.write(bibtext_out)
+    else:
+        fout.write(entry.to_bib())  # just write what we had to start with
+        fout.write('\n')
+
+fout.close()
+
+
+# NOW we reread the temp bib file, which should have all available dois and the best possible
+# citation info, and clean it up to look nicer (esp keys)
+
+parser = bbl.Parser()  # parser for bibtex
+parsed = parser.parse(open('temp.bib','r'))  # parse the input file with biblib
+
+# get entries
+bib_OD = parsed.get_entries()  # returns collections.OrderedDict
+
 # check if all the titles end with an apostrophe; if so, probably an error and they need to 
 # be removed (probably quoted titles and anystyle only removed the leading quote)
+# this may not be an issue anymore since we should get clean titles from crossref mostly?
+# TODO deal with this for things that are not queried
 last_char = np.array([bib_OD[key]['title'][-1] for key in bib_OD])
 strp_last = False
 lc = Counter(last_char)
@@ -42,7 +115,6 @@ if max(lc.values()) >= len(last_char)/2:  # this is a red flag
         strp_last = True  # and we'll remove the one with that index in the keys list
         char_out = list(lc.keys())[irem]
 
-
 # open outfile for writing
 fout = open(out_bib,'w')  # will overwrite if file exists
 
@@ -52,6 +124,7 @@ n_without_doi = 0
 # loop entry keys
 for key in bib_OD:
     entry = bib_OD[key]
+
     # for each, make 'year' and fill with year from 'date'
     if 'date' in entry.keys():
         if len(entry['date']) == 4: # assume this means it's a year, which is probably true
@@ -66,15 +139,13 @@ for key in bib_OD:
     if 'url' in entry.keys():
         if re.search(r"doi\.org",entry['url']):  # check if url is just a doi link
             _ = entry.pop('url')
+# TODO if there is a url but no doi and the url is a doi, repurpose
+
 #    if 'pages' in entry.keys():
 #        _ = entry.pop('pages')
 
     if 'pages' in entry.keys():
         entry['pages'] = entry['pages'].rstrip(',')  # get rid of any trailing commas
-
-    if 'doi' in entry.keys():  # check if doi ends with . and if it does, get rid of the .
-        if entry['doi'][-1] == '.':
-            entry['doi'] = entry['doi'][:-1]
 
     if 'note' in entry.keys():
         entry['note'] = re.sub(r'Available at','',entry['note'])
@@ -87,6 +158,7 @@ for key in bib_OD:
 
     # for each, reformat key to be what we'd look for in inline citations
     # first, count authors: if >2, key is firstauthorEAYYYY, if 2 or less is author(author)YYYY
+    # TODO deal with {} in author lists if it comes up
     if len(entry.authors()) > 2:
         newkey = entry.authors()[0].last + 'EA' + entry['year']
     elif len(entry.authors()) == 2:
@@ -102,18 +174,11 @@ for key in bib_OD:
         nextletter = chr(ord(alphabet[-1]) + 1)
     newkey = newkey + nextletter  # this is what we'll use for bibtex
 
-#   if len(newkey) != len(newkey.encode()):
-#       print('key ascii error: ',newkey)  # non-ascii is fine within citations, just not in keys
-#       newkey2 = input('enter a corrected key to use for this entry: ') or newkey
-#       if newkey2 == newkey:
-#           print('not correcting key; this may cause problems later')
-#       newkey = newkey2
-
     newkey_list.append(newkey)
     entry.key = newkey
 
     # check if doi field is present
-    if 'doi' in entry.keys():
+    if 'doi' in entry.keys() or 'DOI' in entry.keys():
         n_with_doi += 1
     else:
         n_without_doi += 1
@@ -126,4 +191,4 @@ fout.close()
 
 print('%i items have doi, %i do not have doi' % (n_with_doi, n_without_doi))
 print('%.2f percent lack doi' % (100*n_without_doi/(n_with_doi + n_without_doi)))
-print('if many dois are missing, try searching the plain text reference list with %s' % ("https://apps.crossref.org/SimpleTextQuery"))
+#print('if many dois are missing, try searching the plain text reference list with %s' % ("https://apps.crossref.org/SimpleTextQuery"))

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -55,7 +55,6 @@ bib_new = OrderedDict()         # to save entries with DOIs added
 
 for key in bib_OD:  # loop entry keys
     entry = bib_OD[key]
-    # TODO if url us a key and doi is not, check if url is actually a doi
     doi = None   # to start
     if 'doi' in entry.keys(): # get provided doi, check to make sure it will work
         if entry['doi'][-1] == '.':  # check if doi ends with . and if it does, get rid of the .
@@ -70,6 +69,14 @@ for key in bib_OD:  # loop entry keys
             bibtext = urlopen(req).read().decode('utf-8')
         except HTTPError:
             doi = None  # authors made a DOI mistake or anystyle messed up; try a search
+
+    # if url is actually a doi link and we don't have the doi already, try the url
+    if 'url' in entry.keys() and re.search(r"doi\.org",entry['url']) and not doi:
+        req = Request(entry['url'], headers=dict(Accept='application/x-bibtex'))
+        try:
+            bibtext = urlopen(req).read().decode('utf-8')
+        except HTTPError:
+            doi = None  # url is not actually a good DOI link
 
     if not doi:  # try querying crossref for this
         q = cr.works(query_bibliographic=entry['title'],query_author=entry['author'],\

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -89,6 +89,10 @@ for key in bib_OD:  # loop entry keys
         except HTTPError:  # shouldn't happen, but if it does anyway we give up on this one
             continue
         except bbl.FieldError:  # probably no 'author' - might be 'editor'
+            # in this (pretty edge) case, just keep the entry as is and move on
+            entry_new = entry  # keep whatever the initial entry was
+            entry_new.key = key         # keep the input key for now
+            bib_new[key] = entry_new    # as that should be unique, even from anystyle (a/b etc)
             continue
         if q['message']['total-results'] > 0:  # TODO deal with case where exactly 1 result
             q0 = scu.format_crossref_query(q, i=0)

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -227,6 +227,8 @@ for key in bib_new:  # loop entry keys
                 print('no author found! available keys are:')
                 print(entry.keys())
                 akey = input('enter a key to use for author: ') or entry.keys()[0]
+                if akey not in entry.keys():
+                    akey = entry.keys()[0]  # fallback for typos
                 entry['author'] = entry[akey]
             parser = bbl.Parser()  # need to re-parse to get field_pos right in Entry
             parsed = parser.parse(entry.to_bib())
@@ -237,13 +239,17 @@ for key in bib_new:  # loop entry keys
 
         # for each, reformat key to be what we will look for in inline citations
         # first, count authors: if >2, key is firstauthorEAYYYY, if 2 or less is author(author)YYYY
-        if len(entry.authors()) > 2:
-            newkey = auth0 + 'EA' + entry['year']
-        elif len(entry.authors()) == 2:
-            auth1 = re.sub(r'[ ]',r'',entry.authors()[1].last.lstrip('{').rstrip('}'))
-            newkey = auth0 + auth1 + entry['year']
-        elif len(entry.authors()) == 1:
-            newkey = auth0 + entry['year']
+        try:
+            if len(entry.authors()) > 2:
+                newkey = auth0 + 'EA' + entry['year']
+            elif len(entry.authors()) == 2:
+                auth1 = re.sub(r'[ ]',r'',entry.authors()[1].last.lstrip('{').rstrip('}'))
+                newkey = auth0 + auth1 + entry['year']
+            elif len(entry.authors()) == 1:
+                newkey = auth0 + entry['year']
+        except:
+            newkey = auth0+"_messykey"
+            print(newkey)
         newkey = newkey.replace(" ","")  # get rid of spaces if there are any (like van Keken or something)
         newkey = newkey.replace("-","")  # get rid of hyphens, which tex2jats doesn't like
         nextletter = 'a'

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -254,8 +254,8 @@ for key in bib_new:  # loop entry keys
             elif len(entry.authors()) == 1:
                 newkey = auth0 + entry['year']
         except:
-            newkey = auth0+"_messykey"
-            print(newkey)
+            newkey = auth0+"MessyKey"
+            print('problem with key: ',newkey)
         newkey = newkey.replace(" ","")  # get rid of spaces if there are any (like van Keken or something)
         newkey = newkey.replace("-","")  # get rid of hyphens, which tex2jats doesn't like
         nextletter = 'a'
@@ -271,6 +271,9 @@ for key in bib_new:  # loop entry keys
     # check if doi field is present
     if 'doi' in entry.keys() or 'DOI' in entry.keys():
         n_with_doi += 1
+        # escape any underscores that might be in DOIs for the sake of tex
+        # (only do this just before writing bc needs to be clean for queries)
+        entry['doi'] = re.sub(r'_',r'\_',entry['doi'])
     else:
         n_without_doi += 1
 

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -85,7 +85,7 @@ for key in bib_OD:  # loop entry keys
     if not doi:  # try querying crossref to get a doi
         try:
             q = cr.works(query_bibliographic=entry['title'],query_author=entry['author'],\
-                        limit=2,select='DOI,title,author,score,type',sort='score')
+                        limit=2,select='DOI,title,author,score,type,published',sort='score')
         except HTTPError:  # I think this happens when select asks for a nonexistent field, likely type
             q = cr.works(query_bibliographic=entry['title'],query_author=entry['author'],\
                         limit=2,sort='score')

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -6,7 +6,7 @@ from habanero import Crossref
 from argparse import ArgumentParser
 from collections import OrderedDict
 from urllib.request import Request, urlopen, HTTPError
-import os, sys, re, random, string
+import os, sys, re
 
 ####
 # clean up bibtex file produced by anystyle *or* a bib file provided by an author
@@ -20,7 +20,7 @@ import os, sys, re, random, string
 # Usage: 
     # python3 fix_bibtex.py -i path/to/input.bib -o path_to_output.bib <-k>
 
-# TODO format terminal printing/inputs better
+# TODO format terminal printing/inputs better (\033[1m and \033[0m for bold)
 # TODO actually un-tex/html-escape special characters from doi.org bibtex entries?
     # like &lt; and {\'{e}} or whatever (this tends to come up with authors and titles)
     # for now this is taken care of by option to keep old entry title and/or authors

--- a/fix_bibtex.py
+++ b/fix_bibtex.py
@@ -20,6 +20,7 @@ import os, sys, re, random, string
 # Usage: 
     # python3 fix_bibtex.py -i path/to/input.bib -o path_to_output.bib <-k>
 
+# TODO format terminal printing/inputs better
 # TODO actually un-tex/html-escape special characters from doi.org bibtex entries?
     # like &lt; and {\'{e}} or whatever (this tends to come up with authors and titles)
     # for now this is taken care of by option to keep old entry title and/or authors

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -648,10 +648,10 @@ def _test_test_cite(test_cite,bibkeys):
     is_badref = False
     is_abamb = False
 
-    if test_cite.lower() + 'a' not in bibkeys:
+    if test_cite + 'a' not in bibkeys:  # used to be test_cite.lower() for both but biblib preserves case now
         is_badref = True
     else:
-        if test_cite.lower() + 'b' in bibkeys:
+        if test_cite + 'b' in bibkeys:
             is_abamb = True
 
     return is_badref, is_abamb

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -702,6 +702,38 @@ def format_crossref_query(q,ret=['authors','title','doi','score','type','subtype
         out['auths'] = auths
     return out
 
+def print_query_options(q0,i=0):
+    """ Take reformatted dict of query outputs and print relevant info,
+    ask for user input to decide whether the query returned a good match
+    Note: we're assuming title, authors, doi, and score will be in the output dict
+        (type not assumed)
+        this should usually be a good assumption? but could make more robust to keys
+        if it turns out to be an issue
+    """
+    print('received:\ntitle: %s\nby: %s\ndoi: %s\nscore: %.2f\n' % (q0['title'],\
+            q0['auths'], q0['doi'], q0['score']))
+    if 'type' in q0.keys():
+        print('type: %s\n' % q0['type'])
+    if i = 0:
+        iok = input('accept this [y], reject query (n), or try next match (p): ') or 'y'
+    else:
+        iok = input('accept this [y], reject query (n), or use previous match (p): ') or 'y'
+    return iok
+
+def make_doi_url(doi,root='https://dx.doi.org/'):
+    """ Construct url for requesting bibtex based on doi
+    The only cleaning we do is to check if it ends with '. ' which I guess
+        would indicate poor scraping from a sentence termination
+    Some previous versions escaped certain characters (parens?) but that didn't
+        seem to be necessary
+    """
+    if '. ' in doi:
+        ourl = "https://dx.doi.org/"+doi[0:doi.find('. ')]
+    else:
+        ourl = "https://dx.doi.org/"+doi
+    return doi
+
+
 ########################################################################
 # tex escaping for python
 ########################################################################

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -710,13 +710,13 @@ def print_query_options(q0,i=0):
         this should usually be a good assumption? but could make more robust to keys
         if it turns out to be an issue
     """
-    print('received:\ntitle: %s\nby: %s\ndoi: %s\nscore: %.2f\n' % (q0['title'],\
+    print('received:\ntitle: %s\nby: %s\ndoi: %s\nscore: %.2f' % (q0['title'],\
             q0['auths'], q0['doi'], q0['score']))
     if 'type' in q0.keys():
-        print('type: %s\n' % q0['type'])
+        print('type: %s' % q0['type'])
     if 'subtype' in q0.keys():
-        print('subtype: %s\n' % q0['subtype'])
-    if i = 0:
+        print('subtype: %s' % q0['subtype'])
+    if i == 0:
         iok = input('accept this [y], reject query (n), or see next match (p): ') or 'y'
     else:
         iok = input('accept this [y], reject query (n), or use previous match (p): ') or 'y'
@@ -733,7 +733,7 @@ def make_doi_url(doi,root='https://dx.doi.org/'):
         ourl = "https://dx.doi.org/"+doi[0:doi.find('. ')]
     else:
         ourl = "https://dx.doi.org/"+doi
-    return doi
+    return ourl
 
 
 ########################################################################

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -97,7 +97,7 @@ def first_pandoc_clean(ifile,ofile):
         # (which probably means it was a poorly formatted section header)
         if re.match(r'^\\textbf\{[^{]*\}$',line.strip()):
             isfig = bool(re.match(r'^\\textbf\{Figure',line.strip()))
-            istab = bool(re.match(r'^\\textbf\{Figure',line.strip()))
+            istab = bool(re.match(r'^\\textbf\{Table',line.strip()))
             if not isfig and not istab:  # capture content of the tag and reformat
                 newline = re.findall(r'^\\textbf\{([^{]*)\}$',line.strip())[0]
                 newline = '[SECTION HEADER level unknown] {' + newline + '}'

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -672,6 +672,37 @@ def _etal_and(bits):
     return bits
 
 ########################################################################
+# bibtex and crossref stuff
+########################################################################
+
+def format_crossref_query(q,ret=['authors','title','doi','score','type','subtype'],i=0):
+    """ Format information (keys in ret) from a dict (q)
+    that is returned from a crossref query via habanero
+    """
+    out = {}
+    qi = q['message']['items'][i]
+    if 'title' in ret and 'title' in qi.keys():
+        out['title'] = qi['title'][0]
+    if 'doi' in ret and 'DOI' in qi.keys():
+        out['doi'] = qi['DOI']
+    if 'score' in ret and 'score' in qi.keys():
+        out['score'] = qi['score']
+    if 'type' in ret and 'type' in qi.keys():
+        out['type'] = qi['type']
+    if 'subtype' in ret and 'subtype' in qi.keys():
+        out['subtype'] = qi['subtype']
+    if 'authors' in ret and 'author' in qi.keys():
+        auths = ''
+        for a in qi['author']:
+            if 'family' in a.keys() and 'given' in a.keys():
+                auths = auths + a['given'] + ' ' + a['family'] + ', '
+            elif 'name' in a.keys():
+                auths = auths + a['name'] + ', '
+        auths = auths[:-2]
+        out['auths'] = auths
+    return out
+
+########################################################################
 # tex escaping for python
 ########################################################################
 

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -714,8 +714,10 @@ def print_query_options(q0,i=0):
             q0['auths'], q0['doi'], q0['score']))
     if 'type' in q0.keys():
         print('type: %s\n' % q0['type'])
+    if 'subtype' in q0.keys():
+        print('subtype: %s\n' % q0['subtype'])
     if i = 0:
-        iok = input('accept this [y], reject query (n), or try next match (p): ') or 'y'
+        iok = input('accept this [y], reject query (n), or see next match (p): ') or 'y'
     else:
         iok = input('accept this [y], reject query (n), or use previous match (p): ') or 'y'
     return iok

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from re import finditer, findall
+import dateutil.parser as dp
 import re
 import os, sys
 
@@ -675,7 +676,7 @@ def _etal_and(bits):
 # bibtex and crossref stuff
 ########################################################################
 
-def format_crossref_query(q,ret=['authors','title','doi','score','type','subtype'],i=0):
+def format_crossref_query(q,ret=['authors','title','doi','score','type','subtype','pdate'],i=0):
     """ Format information (keys in ret) from a dict (q)
     that is returned from a crossref query via habanero
     """
@@ -691,6 +692,9 @@ def format_crossref_query(q,ret=['authors','title','doi','score','type','subtype
         out['type'] = qi['type']
     if 'subtype' in ret and 'subtype' in qi.keys():
         out['subtype'] = qi['subtype']
+    if 'pdate' in ret and 'published' in qi.keys():
+        if 'date-parts' in qi['published'].keys():
+            out['pdate'] = dp.parse('-'.join([str(e) for e in qi['published']['date-parts'][0]]))
     if 'authors' in ret and 'author' in qi.keys():
         auths = ''
         for a in qi['author']:
@@ -710,12 +714,14 @@ def print_query_options(q0,i=0):
         this should usually be a good assumption? but could make more robust to keys
         if it turns out to be an issue
     """
-    print('received:\ntitle: %s\nby: %s\ndoi: %s\nscore: %.2f' % (q0['title'],\
+    print('received:\n\ttitle: %s\n\tby: %s\n\tdoi: %s\n\tscore: %.2f' % (q0['title'],\
             q0['auths'], q0['doi'], q0['score']))
+    if 'pdate' in q0.keys():
+        print('\tyear: %i' % q0['pdate'].year)
     if 'type' in q0.keys():
-        print('type: %s' % q0['type'])
+        print('\ttype: %s' % q0['type'])
     if 'subtype' in q0.keys():
-        print('subtype: %s' % q0['subtype'])
+        print('\tsubtype: %s' % q0['subtype'])
     if i == 0:
         iok = input('accept this [y], reject query (n), or see next match (p): ') or 'y'
     else:

--- a/sce_utils/utils.py
+++ b/sce_utils/utils.py
@@ -735,6 +735,8 @@ def make_doi_url(doi,root='https://dx.doi.org/'):
     Some previous versions escaped certain characters (parens?) but that didn't
         seem to be necessary
     """
+    if doi.lstrip().lower().startswith('doi:'):
+        doi = doi.lstrip()[4:].lstrip()  # get rid of any doi: 10.etc syntax (old style)
     if '. ' in doi:
         ourl = "https://dx.doi.org/"+doi[0:doi.find('. ')]
     else:


### PR DESCRIPTION
This PR mostly updates the fix_bibtex script. There is an option to not use the updated version (command line flag --nosearch) if you just want basic cleaning with no crossref stuff. The updated version queries crossref for each article and either cleans/updates the entry if it comes with a DOI, or attempts to find a DOI for it (with user input) if it is DOI-less at the start. Cleaning via crossref helps eliminate errors introduced by anystyle, but may also cause some small errors later in parsing pandoc files (in particular, if the author used a year for the paper that doesn't match what's in crossref's database - sometimes people get publication dates wrong by 1).  Note that there is also a flag --keepkeys which makes it possible to run fix_bibtex on a bib file without changing the entry keys - useful if you want to try and add DOIs to a reference file that came with a tex template submission and thus the keys should not be standardized  as we do for docx/odt parsing.