### PR TITLE
parsing for manuscript type section in docx/odt templates

### DIFF
--- a/sce_utils/tex_templates.py
+++ b/sce_utils/tex_templates.py
@@ -14,6 +14,13 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
     if breakmath: docops += 'breakmath,'
     if preprint: docops += 'preprint,'
 
+    if re.search('invited',manu.lower()):
+        docops += 'invited,'
+        manu = re.sub(r'Invited',r'',manu)  # remove "invited" cap or non-cap from string
+        manu = re.sub(r'invited',r'',manu)  # bc it goes in docops
+        manu = manu.strip().strip(',')
+
+    # set up for report header if it's a report
     report_string = """% if a report, specify report type:
 """
     if re.search('report',manu.lower()):
@@ -21,10 +28,9 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
         docops += 'report,'
     else:
         report_string += """%\\reportheader{Report Type Here}"""
-    if re.search('invited',manu.lower()):
-        docops += 'invited,'
-        #manu = re.
+    # opinion is its own thing and is only in docops, no such thing as a "Fast Report Opinion" atm
     if re.search('opinion',manu.lower()): docops += 'opinion,'
+
     docops = docops[:-1]  # remove trailing comma
 
     header1 = """% Seismica Publication Template

--- a/sce_utils/tex_templates.py
+++ b/sce_utils/tex_templates.py
@@ -1,8 +1,8 @@
-import os, sys, datetime
+import os, sys, datetime, re
 
 def set_up_header(fout,title,authors={},affils={},credits={},\
                   anon=False,langs=False,breakmath=False,preprint=False,\
-                  other_langs=[]):
+                  other_langs=[],manu='article'):
     """
     write out the basic seismica latex header
     fout is an open file handler ready for writing this header
@@ -13,6 +13,16 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
     if langs: docops += 'languages,'
     if breakmath: docops += 'breakmath,'
     if preprint: docops += 'preprint,'
+
+    report_string = """% if a report, specify report type:
+"""
+    if re.search('report',manu.lower()):
+        report_string += """\\reportheader{""" + manu + """}"""
+        docops += 'report,'
+    else:
+        report_string += """%\\reportheader{Report Type Here}"""
+    if re.search('invited',manu.lower()): docops += 'invited,'
+    if re.search('opinion',manu.lower()): docops += 'opinion,'
     docops = docops[:-1]  # remove trailing comma
 
     header1 = """% Seismica Publication Template
@@ -23,14 +33,7 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % options: report, breakmath, proof, onecolumn, invited, opinion
 \documentclass["""+docops+"""]{seismica} 
-
-% if a report, specify report type:
-%\\reportheader{Fast Report}
-%\\reportheader{Null Results Report}
-%\\reportheader{Software Report}
-%\\reportheader{Instrument Deployment Report}
-%\\reportheader{Field Campaign Report}
-
+"""+report_string+"""
 % SCE team metadata:
 \dois{10.26443/seismica.v0i0.N}
 \\receiveddate{DATE HERE}
@@ -76,8 +79,7 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
     fout.write('\n')
 
     if len(other_langs) > 0:
-        header2 = """\\setotherlanguages{
-"""
+        header2 = """\\setotherlanguages{"""
         for l in other_langs:
             header2 += '%s,' % l
         header2 = header2[:-1]

--- a/sce_utils/tex_templates.py
+++ b/sce_utils/tex_templates.py
@@ -21,7 +21,9 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
         docops += 'report,'
     else:
         report_string += """%\\reportheader{Report Type Here}"""
-    if re.search('invited',manu.lower()): docops += 'invited,'
+    if re.search('invited',manu.lower()):
+        docops += 'invited,'
+        #manu = re.
     if re.search('opinion',manu.lower()): docops += 'opinion,'
     docops = docops[:-1]  # remove trailing comma
 
@@ -32,25 +34,25 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
 %! TEX encoding = UTF-8 Unicode
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % options: report, breakmath, proof, onecolumn, invited, opinion
-\documentclass["""+docops+"""]{seismica} 
+\\documentclass["""+docops+"""]{seismica} 
 """+report_string+"""
 % SCE team metadata:
-\dois{10.26443/seismica.v0i0.N}
+\\dois{10.26443/seismica.v0i0.N}
 \\receiveddate{DATE HERE}
 \\accepteddate{DATE HERE}
-\publisheddate{DATE HERE}
+\\publisheddate{DATE HERE}
 \\theyear{"""+str(datetime.datetime.now().year)+"""}
 \\thevolume{0}
 \\thenumber{0}
-\prodedname{the production editor}
-\handedname{the handling editor}
-\copyedname{the copy/layout editor}
+\\prodedname{the production editor}
+\\handedname{the handling editor}
+\\copyedname{the copy/layout editor}
 %\\reviewername{signed reviewer(s)}
 %\\translatorname{translator(s)}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \\title{"""+title+"""}
-\shorttitle{"""+title+"""}
+\\shorttitle{"""+title+"""}
 
 """
     fout.write(header1)
@@ -62,7 +64,7 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
         if ik > 0:
             towrite = towrite.replace(' ','~')
         if 'orcid' in auth.keys():
-            towrite += '\n\orcid{'+auth['orcid']+'}'
+            towrite += '\n\\orcid{'+auth['orcid']+'}'
         if 'corresp' in auth.keys():
             towrite += '\n\\thanks{Corresponding author: '+auth['corresp']+'}'
         towrite += '}\n'
@@ -75,7 +77,7 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
     fout.write('\n')
 
     for k in credits.keys():
-        fout.write('\credit{'+k+'}{'+credits[k]+'}\n')
+        fout.write('\\credit{'+k+'}{'+credits[k]+'}\n')
     fout.write('\n')
 
     if len(other_langs) > 0:
@@ -84,9 +86,9 @@ def set_up_header(fout,title,authors={},affils={},credits={},\
             header2 += '%s,' % l
         header2 = header2[:-1]
         header2 += """}\n
-%% Do not put arabic in \setotherlanguages{} as it is not supported by polyglossia
+%% Do not put arabic in \\setotherlanguages{} as it is not supported by polyglossia
 %% Instead, use these commands within the text:
-%%\\begin{Arabic} and \end{Arabic} around paragraphs in Arabic
+%%\\begin{Arabic} and \\end{Arabic} around paragraphs in Arabic
 %%\\n{} to wrap any digits within Arabic text that should read left-to-right
 %%\\textarabic{} for Arabic text embedded in a left-to-right paragraph
 
@@ -102,16 +104,16 @@ def add_abstracts(fout,summaries):
     write abstract(s) and optional non-technical summary into file after header
     """
     towrite = """
-\makeseistitle{\n"""
+\\makeseistitle{\n"""
     for k in summaries.keys():
         abst = summaries[k]
         toadd = ''
         if abst['language'] != 'English':
             toadd += "\\begin{%s}\n" % abst['language']
         toadd += "\\begin{summary}{%s}\n" % abst['name']
-        toadd += "%s\n\end{summary}\n" % abst['text']
+        toadd += "%s\n\\end{summary}\n" % abst['text']
         if abst['language'] != 'English':
-            toadd += "\end{%s}\n" % abst['language']
+            toadd += "\\end{%s}\n" % abst['language']
         towrite += toadd
 
     towrite += "}\n"


### PR DESCRIPTION
docx/odt templates just added a place to specify the manuscript type, intended to help avoid missing info/miscommunication about what categories articles should be in. The pandoc post-processing has been updated accordingly to catch and handle the "Manuscript type" section when it is present, and to attempt an automatic fill for the reporttype macro in the tex publication template. It also tries to handle "Invited" tags and "Opinion" in a nice way.